### PR TITLE
fix version number of pycountry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         'humanfriendly',
         'jsonpickle',
         'jsonschema',
-        'pycountry',
+        'pycountry<=19.8.18',
         'requests',
         'pyyaml',
         'six',


### PR DESCRIPTION
limit max version of pycountry to v19.x. v20 of pycountry dropped python2 support.