### PR TITLE
Use properties

### DIFF
--- a/mapactionpy_controller/plugin_base.py
+++ b/mapactionpy_controller/plugin_base.py
@@ -1,7 +1,6 @@
 import errno
 import glob
 import logging
-# import math
 import os
 from operator import itemgetter
 import re
@@ -24,7 +23,6 @@ class BaseRunnerPlugin(object):
     def __init__(self, hum_event, ** kwargs):
         self.hum_event = hum_event
         self.cmf = CrashMoveFolder(self.hum_event.cmf_descriptor_path)
-        #self.themes = set()
 
         if not self.cmf.verify_paths():
             raise ValueError("Cannot find paths and directories referenced by cmf {}".format(self.cmf.path))

--- a/mapactionpy_controller/plugin_base.py
+++ b/mapactionpy_controller/plugin_base.py
@@ -1,6 +1,7 @@
 import errno
 import glob
 import logging
+# import math
 import os
 from operator import itemgetter
 import re
@@ -23,6 +24,7 @@ class BaseRunnerPlugin(object):
     def __init__(self, hum_event, ** kwargs):
         self.hum_event = hum_event
         self.cmf = CrashMoveFolder(self.hum_event.cmf_descriptor_path)
+        #self.themes = set()
 
         if not self.cmf.verify_paths():
             raise ValueError("Cannot find paths and directories referenced by cmf {}".format(self.cmf.path))
@@ -215,8 +217,8 @@ class BaseRunnerPlugin(object):
             export_params = self._create_export_dir(export_params, recipe)
             if 'properties' in kwargs:
                 properties = kwargs['properties']
-                export_params['themes'] = properties.get('themes', set())
-
+                for key in list(properties.keys()):
+                    export_params[str(key)] = properties[str(key)]
             export_params = self._do_export(export_params, recipe)
         except Exception as exp:
             logger.error('Failed to export the map. export_params = "{}"'.format(export_params))

--- a/mapactionpy_controller/xml_exporter.py
+++ b/mapactionpy_controller/xml_exporter.py
@@ -44,24 +44,24 @@ class XmlExporter:
         exportPropertiesDict["product-type"] = params["productType"]
         exportPropertiesDict["summary"] = params["summary"]
         # Fixed values
-        exportPropertiesDict["imagerydate"] = ""
-        exportPropertiesDict["papersize"] = "A3"
-        exportPropertiesDict["access"] = "MapAction"  # Until we work out how to get the values for this
-        exportPropertiesDict["accessnotes"] = ""
-        exportPropertiesDict["location"] = ""
-        exportPropertiesDict["qclevel"] = "Automatically generated"
-        exportPropertiesDict["qcname"] = ""
-        exportPropertiesDict["proj"] = ""
-        exportPropertiesDict["datasource"] = ""
-        exportPropertiesDict["kmlresolutiondpi"] = ""
-        exportPropertiesDict["paperxmax"] = ""
-        exportPropertiesDict["paperxmin"] = ""
-        exportPropertiesDict["paperymax"] = ""
-        exportPropertiesDict["paperymin"] = ""
-        exportPropertiesDict["createdate"] = None
-        exportPropertiesDict["createtime"] = None
-        exportPropertiesDict["scale"] = None
-        exportPropertiesDict["datum"] = None
+        exportPropertiesDict["imagerydate"] = params.get('imagerydate', "")
+        exportPropertiesDict["papersize"] = params.get('papersize', "A3")
+        exportPropertiesDict["access"] = params.get('access', "MapAction")
+        exportPropertiesDict["accessnotes"] = params.get('accessnotes', "")
+        exportPropertiesDict["location"] = params.get('location', "")
+        exportPropertiesDict["qclevel"] = params.get('qclevel', "Automatically generated")
+        exportPropertiesDict["qcname"] = params.get('qcname', "")
+        exportPropertiesDict["proj"] = params.get('proj', "")
+        exportPropertiesDict["datasource"] = params.get('datasource', "")
+        exportPropertiesDict["kmlresolutiondpi"] = params.get('kmlresolutiondpi', "")
+        exportPropertiesDict["paperxmax"] = params.get('paperxmax', "")
+        exportPropertiesDict["paperxmin"] = params.get('paperxmin', "")
+        exportPropertiesDict["paperymax"] = params.get('paperymax', "")
+        exportPropertiesDict["paperymin"] = params.get('paperymin', "")
+        exportPropertiesDict["createdate"] = params.get('createdate', "")
+        exportPropertiesDict["createtime"] = params.get('createtime', "")
+        exportPropertiesDict["scale"] = params.get('scale', "")
+        exportPropertiesDict["datum"] = params.get('datum', "")
 
         if (params["versionNumber"] == 1):
             exportPropertiesDict["status"] = "New"

--- a/mapactionpy_controller/xml_exporter.py
+++ b/mapactionpy_controller/xml_exporter.py
@@ -62,12 +62,6 @@ class XmlExporter:
         exportPropertiesDict["createtime"] = params.get('createtime', "")
         exportPropertiesDict["scale"] = params.get('scale', "")
         exportPropertiesDict["datum"] = params.get('datum', "")
-
-        if (params["versionNumber"] == 1):
-            exportPropertiesDict["status"] = "New"
-        else:
-            exportPropertiesDict["status"] = "Update"
-
         exportPropertiesDict["language-iso2"] = self.event.language_iso2
         exportPropertiesDict["pdfresolutiondpi"] = self.event.default_pdf_res_dpi
         exportPropertiesDict["jpgresolutiondpi"] = self.event.default_jpeg_res_dpi
@@ -75,6 +69,12 @@ class XmlExporter:
         exportPropertiesDict["glideno"] = self.event.glide_number
         exportPropertiesDict["operationID"] = self.event.operation_id
         exportPropertiesDict["sourceorg"] = self.event.default_source_organisation
+
+        if (params["versionNumber"] == 1):
+            exportPropertiesDict["status"] = "New"
+        else:
+            exportPropertiesDict["status"] = "Update"
+
         language = pycountry.languages.get(alpha_2=self.event.language_iso2)
         if (language is not None):
             exportPropertiesDict["language"] = language.name


### PR DESCRIPTION
Change of plan; the MapAction Toolbar might want to override many other properties in the export XML.
Previous version handled a themes set, -this version takes a dictionary named 'properties' which optionally contains properties to override. 