### PR TITLE
Include schemas folder in setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ In no particular order:
 
  [] Improve the constructors for the Event and CrashMoveFolder classes. It should be possible to round-robin between the instance and the json representation. eg there should be tests which look something like this:
 ```
-    assert my_event == Event.fromJOSN(my_event.toJSON())
+    assert my_event == Event.fromJSON(my_event.toJSON())
     assert my_cmf == CrashMoveFolder.fromJOSN(my_cmf.toJSON())
-```   
+```
 The `jsonpickle` module is particularly well suited for this.
 
  [] Implement json schema validation for the various json files.
@@ -28,8 +28,6 @@ The `jsonpickle` module is particularly well suited for this.
 
  [] Better name for the `Event` class
 
- [] Use explict class names for validator in the Naming Convention config files. 
+ [] Use explict class names for validator in the Naming Convention config files.
 
- [] Document the process of creating the Naming Convention classes for validating specific clause types. 
-
-
+ [] Document the process of creating the Naming Convention classes for validating specific clause types.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ def _get_version_number():
 
 
 def get_gis_environment():
-    gis_dependancies = []
+    gis_dependencies = []
 
     # The key is the module name that is detected
     # The value is the module name that will be installed if the key is detected.
@@ -54,13 +54,13 @@ def get_gis_environment():
         try:
             sys.stderr.write('\ntrying to import {}\n'.format(env_mod))
             importlib.import_module(env_mod)
-            gis_dependancies.append(target_mod)
-            sys.stderr.write('\nsucessed importing {}, added {} to gis_dependancies\n'.format(env_mod, target_mod))
+            gis_dependencies.append(target_mod)
+            sys.stderr.write('\nsuccessed importing {}, added {} to gis_dependencies\n'.format(env_mod, target_mod))
         except ImportError:
             sys.stderr.write('\nfailed to import {}\n'.format(env_mod))
             # pass
 
-    return gis_dependancies
+    return gis_dependencies
 
 
 setup(
@@ -79,6 +79,8 @@ setup(
         ]
     },
     packages=find_packages(),
+    package_dir={'mapactionpy_controller': 'mapactionpy_controller'},
+    package_data={'mapactionpy_controller': ['schemas/*.schema']},
     include_package_data=True,
     install_requires=[
         'chevron',

--- a/temp_setup_test.py
+++ b/temp_setup_test.py
@@ -1,19 +1,25 @@
 def get_gis_environment():
-    gis_dependancies = []
+    gis_dependencies = []
 
     try:
         import arcpy  # noqa
-        gis_dependancies.append('mapactionpy_arcmap')
+        gis_dependencies.append('mapactionpy_arcmap')
+    except ImportError:
+        pass
+
+    try:
+        import arcpy  # noqa
+        gis_dependencies.append('mapactionpy_arcpro')
     except ImportError:
         pass
 
     try:
         import qgis.core  # noqa
-        gis_dependancies.append('mapactionpy_qgis')
+        gis_dependencies.append('mapactionpy_qgis')
     except ImportError:
         pass
 
-    return gis_dependancies
+    return gis_dependencies
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Had to explicitly include the schemas folder in the setup.py file otherwise they weren't packaged for Python 3 installations.